### PR TITLE
Attempted .vti VTKViewer Rework

### DIFF
--- a/frontend/src/VTKViewer.js
+++ b/frontend/src/VTKViewer.js
@@ -1,136 +1,156 @@
-import React, { useRef, useLayoutEffect } from "react";
+import React, { useRef, useEffect } from "react";
 import vtkRenderWindow from "vtk.js/Sources/Rendering/Core/RenderWindow";
 import vtkRenderer from "vtk.js/Sources/Rendering/Core/Renderer";
 import vtkOpenGLRenderWindow from "vtk.js/Sources/Rendering/OpenGL/RenderWindow";
 import vtkRenderWindowInteractor from "vtk.js/Sources/Rendering/Core/RenderWindowInteractor";
 import vtkInteractorStyleTrackballCamera from "vtk.js/Sources/Interaction/Style/InteractorStyleTrackballCamera";
-import vtkOBJReader from "vtk.js/Sources/IO/Misc/OBJReader";
-import vtkMapper from "vtk.js/Sources/Rendering/Core/Mapper";
-import vtkActor from "vtk.js/Sources/Rendering/Core/Actor";
+import vtkXMLImageDataReader from "vtk.js/Sources/IO/XML/XMLImageDataReader";
+import vtkVolumeMapper from "vtk.js/Sources/Rendering/Core/VolumeMapper";
+import vtkVolume from "vtk.js/Sources/Rendering/Core/Volume";
+import vtkColorTransferFunction from "vtk.js/Sources/Rendering/Core/ColorTransferFunction";
+import vtkPiecewiseFunction from "vtk.js/Sources/Common/DataModel/PiecewiseFunction";
 
 const VTKViewer = () => {
   const containerRef = useRef(null);
 
-  useLayoutEffect(() => {
+  const rendererRef = useRef(null);
+  const renderWindowRef = useRef(null);
+  const openGLRef = useRef(null);
+  const interactorRef = useRef(null);
+  const rendererInitialized = useRef(false);
+  const resizeObserverRef = useRef(null);
+
+  const initRenderer = () => {
+    if (rendererInitialized.current) return;
+
     const container = containerRef.current;
     if (!container) return;
 
     const rect = container.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) return;
 
-    // --- Renderer Setup ---
     const renderWindow = vtkRenderWindow.newInstance();
-    const renderer = vtkRenderer.newInstance({ background: [0.1, 0.1, 0.1] });
+    const renderer = vtkRenderer.newInstance({ background: [0, 0, 0] });
     renderWindow.addRenderer(renderer);
 
-    // --- OpenGL Canvas ---
     const openGLRenderWindow = vtkOpenGLRenderWindow.newInstance();
     renderWindow.addView(openGLRenderWindow);
     openGLRenderWindow.setContainer(container);
     openGLRenderWindow.setSize(rect.width, rect.height);
 
-    // --- Interactor ---
     const interactor = vtkRenderWindowInteractor.newInstance();
     interactor.setView(openGLRenderWindow);
     interactor.initialize();
-    interactor.bindEvents(container);
-    const style = vtkInteractorStyleTrackballCamera.newInstance();
-    interactor.setInteractorStyle(style);
+    interactor.setContainer(container);
+    interactor.setInteractorStyle(vtkInteractorStyleTrackballCamera.newInstance());
 
-    // --- Add basic lighting ---
-    const lights = renderer.getLights();
-    if (lights.length) {
-      lights[0].setIntensity(1.2); // brighten the scene
-    }
+    renderWindowRef.current = renderWindow;
+    rendererRef.current = renderer;
+    openGLRef.current = openGLRenderWindow;
+    interactorRef.current = interactor;
 
-    // --- OBJ Loader ---
-    const reader = vtkOBJReader.newInstance();
-    const mapper = vtkMapper.newInstance();
-    const actor = vtkActor.newInstance();
-
-    const modelUrl =
-      "https://raw.githubusercontent.com/alecjacobson/common-3d-test-models/master/data/cow.obj";
-
-    fetch(modelUrl)
-      .then((res) => res.text())
-      .then((objText) => {
-        reader.parseAsText(objText);
-        const polydata = reader.getOutputData();
-
-        mapper.setScalarVisibility(false); // ignore scalar coloring
-        mapper.setInputData(polydata);
-        actor.setMapper(mapper);
-        actor.getProperty().setColor(1, 1, 1); // white cow
-        try {
-        renderer.addActor(actor);
-        } catch (e) {
-        console.warn("VTK internal includes error ignored:", e);
-        }
-
-
-        // --- Auto scale and center ---
-        const bounds = actor.getBounds();
-        const xSize = bounds[1] - bounds[0];
-        const ySize = bounds[3] - bounds[2];
-        const zSize = bounds[5] - bounds[4];
-        const maxSize = Math.max(xSize, ySize, zSize);
-
-        if (maxSize > 0) {
-          const scaleFactor = 20 / maxSize;
-          actor.setScale(scaleFactor, scaleFactor, scaleFactor);
-        }
-
-        const centerX = (bounds[0] + bounds[1]) / 2;
-        const centerY = (bounds[2] + bounds[3]) / 2;
-        const centerZ = (bounds[4] + bounds[5]) / 2;
-        actor.setPosition(-centerX, -centerY, -centerZ);
-
-        // --- Camera framing ---
-        renderer.resetCamera();
-        renderer.getActiveCamera().setFocalPoint(0, 0, 0);
-        renderer.resetCameraClippingRange();
-
-        renderWindow.render();
-        console.log("Actor bounds:", actor.getBounds());
-        console.log("Render complete ✅");
-      })
-      .catch((err) =>
-        console.error(
-          "Failed to load OBJ model (ignore internal includes error):",
-          err
-        )
-      );
-
-    // --- Handle Resize ---
-    const resizeObserver = new ResizeObserver(() => {
+    const observer = new ResizeObserver(() => {
       const rect = container.getBoundingClientRect();
       openGLRenderWindow.setSize(rect.width, rect.height);
       renderWindow.render();
     });
-    resizeObserver.observe(container);
+    observer.observe(container);
+    resizeObserverRef.current = observer;
 
-    // --- Cleanup ---
+    rendererInitialized.current = true;
+  };
+
+  const handleFile = (event) => {
+    initRenderer();
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const arrayBuffer = reader.result;
+      const vtkReader = vtkXMLImageDataReader.newInstance();
+
+      try {
+        vtkReader.parseAsArrayBuffer(arrayBuffer);
+        const image = vtkReader.getOutputData();
+        if (!image) {
+          console.error("Failed to parse VTI file or empty output.");
+          return;
+        }
+
+        rendererRef.current.getVolumes().slice().forEach((v) =>
+          rendererRef.current.removeVolume(v)
+        );
+
+        const mapper = vtkVolumeMapper.newInstance();
+        mapper.setInputData(image);
+        mapper.setSampleDistance(0.1);
+
+        const volume = vtkVolume.newInstance();
+        volume.setMapper(mapper);
+
+        const scalars = image.getPointData().getScalars();
+        if (!scalars) {
+          console.error("No scalar data in VTI file.");
+          return;
+        }
+        const [min, max] = scalars.getRange();
+        console.log("Scalar range:", min, max);
+
+        const ctfun = vtkColorTransferFunction.newInstance();
+        const ofun = vtkPiecewiseFunction.newInstance();
+        ctfun.addRGBPoint(min, 0, 0, 0);
+        ctfun.addRGBPoint(max, 1, 1, 1);
+        ofun.addPoint(min, 0.05);
+        ofun.addPoint(max, 0.9);
+
+        volume.getProperty().setRGBTransferFunction(0, ctfun);
+        volume.getProperty().setScalarOpacity(0, ofun);
+        volume.getProperty().setInterpolationTypeToLinear();
+        volume.getProperty().setShade(true);
+        volume.getProperty().setAmbient(0.2);
+        volume.getProperty().setDiffuse(0.7);
+        volume.getProperty().setSpecular(0.3);
+
+        rendererRef.current.addVolume(volume);
+        rendererRef.current.resetCamera();
+        rendererRef.current.resetCameraClippingRange();
+
+        const camera = rendererRef.current.getActiveCamera();
+        camera.zoom(1.2);
+
+        renderWindowRef.current.render();
+      } catch (err) {
+        console.error("Failed to load VTI file:", err);
+      }
+    };
+    reader.readAsArrayBuffer(file);
+  };
+
+  // Initialize renderer once on mount
+  useEffect(() => {
+    initRenderer();
     return () => {
-      resizeObserver.disconnect();
-      interactor.unbindEvents(container);
-      renderWindow.delete();
-      renderer.delete();
-      openGLRenderWindow.delete();
-      interactor.delete();
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+      }
     };
   }, []);
 
   return (
-    <div
-      ref={containerRef}
-      style={{
-        width: "100%",
-        height: "500px", // visible size
-        background: "#111",
-        borderRadius: "8px",
-        overflow: "hidden",
-      }}
-    />
+    <div>
+      <input type="file" accept=".vti" onChange={handleFile} />
+      <div
+        ref={containerRef}
+        style={{
+          width: "100%",
+          height: "500px",
+          background: "#000",
+          borderRadius: "8px",
+          marginTop: "10px",
+        }}
+      />
+    </div>
   );
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "vtk.js": "^29.11.2"
+        "@kitware/vtk.js": "^34.15.0",
+        "vtk.js": "^34.15.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1475,13 +1476,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
-      "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1593,6 +1591,40 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kitware/vtk.js": {
+      "version": "34.15.0",
+      "resolved": "https://registry.npmjs.org/@kitware/vtk.js/-/vtk.js-34.15.0.tgz",
+      "integrity": "sha512-/UeKRk8TkR4Sb4qOxBbHmncDYv4ycCuayYkrqL0YgPSj0aC3DneGc69L0hpj8DdRg+RyUaqyIfCJuvKKnfDnHA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.28.2",
+        "@types/webxr": "^0.5.5",
+        "commander": "9.2.0",
+        "d3-scale": "4.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "fflate": "0.7.3",
+        "gl-matrix": "3.4.3",
+        "globalthis": "1.0.3",
+        "seedrandom": "3.0.5",
+        "shader-loader": "1.3.1",
+        "shelljs": "0.8.5",
+        "spark-md5": "3.0.2",
+        "stream-browserify": "3.0.0",
+        "utif": "3.1.0",
+        "webworker-promise": "0.5.0",
+        "worker-loader": "3.0.8",
+        "xmlbuilder2": "3.0.2"
+      },
+      "bin": {
+        "vtkDataConverter": "Utilities/DataGenerator/convert-cli.js",
+        "xml2json": "Utilities/XMLConverter/xml2json-cli.js"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.17.10",
+        "autoprefixer": "^10.4.7",
+        "wslink": ">=1.1.0 || ^2.0.0"
       }
     },
     "node_modules/@oozcitak/dom": {
@@ -2925,6 +2957,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3046,12 +3084,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/regexpu-core": {
       "version": "6.4.0",
@@ -3468,6 +3500,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/utif": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/utif/-/utif-3.1.0.tgz",
+      "integrity": "sha512-WEo4D/xOvFW53K5f5QTaTbbiORcm2/pCL9P6qmJnup+17eYfKaEhDeX9PeQkuyEoIxlbGklDuGl8xwuXYMrrXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.5"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3475,12 +3516,12 @@
       "license": "MIT"
     },
     "node_modules/vtk.js": {
-      "version": "29.11.2",
-      "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-29.11.2.tgz",
-      "integrity": "sha512-JDzb6hCPmzqU6BqbtX0hp9w2qlxHOMf9bVkAnQJ4MiKFGz51O+/m1FdCCUFq/z0BjKjR4V4eZSQqxoCCOefwTQ==",
+      "version": "34.15.0",
+      "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-34.15.0.tgz",
+      "integrity": "sha512-FLcSPWMWffBUg4+YhUULw2072/PgLQm6hLhDC+CQ4/RztXglclTkTVavjUA04qlMd1gg+Df1l/J+ezjiWVmfVA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@babel/runtime": "7.22.11",
+        "@babel/runtime": "^7.28.2",
         "@types/webxr": "^0.5.5",
         "commander": "9.2.0",
         "d3-scale": "4.0.2",
@@ -3493,6 +3534,7 @@
         "shelljs": "0.8.5",
         "spark-md5": "3.0.2",
         "stream-browserify": "3.0.0",
+        "utif": "3.1.0",
         "webworker-promise": "0.5.0",
         "worker-loader": "3.0.8",
         "xmlbuilder2": "3.0.2"
@@ -3504,7 +3546,7 @@
       "peerDependencies": {
         "@babel/preset-env": "^7.17.10",
         "autoprefixer": "^10.4.7",
-        "wslink": "^1.1.0"
+        "wslink": ">=1.1.0 || ^2.0.0"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "vtk.js": "^29.11.2"
+    "@kitware/vtk.js": "^34.15.0",
+    "vtk.js": "^34.15.0"
   }
 }


### PR DESCRIPTION
This is an attempt to rework VTKViewer.js so that it renders .vti files instead of .obj files. I opted to use a file upload instead of hosting the file on the dev server to bypass the file fetching system entirely for easier debugging. I also chose to use.vti files directly instead of .dcm files as .vti files are what are generated after processing the .dcm files. It makes it so that it is easier to reimplement the .dcm compatibility while being able to test the expected output. 

The component seems to mount properly, but the result is still the same as the original version in that the component only has a background with no signs of the rendered model. There are also no signs of the file not being read properly within the console.