### PR TITLE
add metadata and DICOM endpoint for physical dimensions

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -198,6 +198,158 @@ def render_dicom(upload_id):
     # 4. Use Flask's safe send_from_directory instead of send_file
     return send_from_directory(dicom_dir, output_filename, mimetype="application/octet-stream")
 
+@app.route("/api/render_dicom/<upload_id>/metadata", methods=["GET"])
+def render_dicom_metadata(upload_id):
+    """Extract physical dimensions and metadata from the DICOM series."""
+
+    safe_upload_id = secure_filename(upload_id)
+    if not safe_upload_id:
+        return jsonify({"error": "Invalid upload ID"}), 400
+    
+    base_uploads = os.path.abspath(UPLOAD_FOLDER)
+    dicom_dir = os.path.abspath(os.path.join(base_uploads, safe_upload_id))
+
+    if not dicom_dir.startswith(base_uploads):
+        return jsonify({"error": "Path traversal attempt detected"}), 403
+    
+    if not os.path.exists(dicom_dir):
+        return jsonify({"error": "Upload ID not found"}), 404
+    
+    dicom_files = [f for f in os.listdir(dicom_dir) if f.lower().endswith(".dcm")]
+
+    if not dicom_files:
+        return jsonify({"error": "No DICOM files found"}), 404
+    
+    try:
+        first_dicom = os.path.join(dicom_dir, dicom_files[0])
+        ds = pydicom.dcmread(first_dicom)
+
+        rows = int(ds.Rows) if hasattr(ds, "Rows") else None
+        cols = int(ds.Columns) if hasattr(ds, "Columns") else None
+
+        pixel_spacing = getattr(ds, "PixelSpacing", [None, None])
+        slice_thickness = getattr(ds, "SliceThickness", None)
+
+        spacing_between_slices = None
+        if hasattr(ds, "SpacingBetweenSlices"):
+            spacing_between_slices = float(ds.SpacingBetweenSlices)
+
+         # Patient Info 
+        patient_name = str(ds.PatientName) if hasattr(ds, "PatientName") else None
+        patient_id = str(ds.PatientID) if hasattr(ds, "PatientID") else None
+        patient_birth_date = str(ds.PatientBirthDate) if hasattr(ds, "PatientBirthDate") else None
+        patient_sex = str(ds.PatientSex) if hasattr(ds, "PatientSex") else None
+
+        # Study Info
+        study_date = str(ds.StudyDate) if hasattr(ds, "StudyDate") else None
+        study_time = str(ds.StudyTime) if hasattr(ds, "StudyTime") else None
+        study_description = str(ds.StudyDescription) if hasattr(ds, "StudyDescription") else None
+
+        #Series Info
+        series_description = str(ds.SeriesDescription) if hasattr(ds, "SeriesDescription") else None
+        series_number = str(ds.SeriesNumber) if hasattr(ds, "SeriesNumber") else None
+        modality = str(ds.Modality) if hasattr(ds, "Modality") else None
+        window_center = str(ds.WindowCenter) if hasattr(ds, "WindowCenter") else None
+        window_width = str(ds.WindowWidth) if hasattr(ds, "WindowWidth") else None
+        rescale_slope = str(ds.RescaleSlope) if hasattr(ds, "RescaleSlope") else None
+        rescale_intercept = str(ds.RescaleIntercept) if hasattr(ds, "RescaleIntercept") else None
+
+        # Volume Dimensions
+        volume_depth = len(dicom_files)
+        if slice_thickness:
+            physical_depth = volume_depth * slice_thickness
+        else:
+            physical_depth = None
+
+
+        # First Slice Intensity Range
+        pixel_array = ds.pixel_array
+        intensity_min = float(np.min(pixel_array))
+        intensity_max = float(np.max(pixel_array))
+        
+        metadata = {
+            "upload_id": upload_id,
+            "physical_dimensions": {
+                "rows": rows,
+                "columns": columns,
+                "pixel_spacing_mm": pixel_spacing,
+                "slice_thickness_mm": slice_thickness,
+                "spacing_between_slices_mm": spacing_between_slices,
+                "number_of_slices": volume_depth,
+                "physical_height_mm": rows * pixel_spacing[1] if pixel_spacing and rows and len(pixel_spacing) > 1 and pixel_spacing[1] else None,
+                "physical_width_mm": columns * pixel_spacing[0] if pixel_spacing and columns and len(pixel_spacing) > 0 and pixel_spacing[0] else None,
+                "physical_depth_mm": physical_depth
+            },
+            "patient_info": {
+                "name": patient_name,
+                "id": patient_id,
+                "birth_date": patient_birth_date,
+                "sex": patient_sex
+            },
+            "study_info": {
+                "date": study_date,
+                "time": study_time,
+                "description": study_description
+            },
+            "series_info": {
+                "description": series_description,
+                "number": series_number,
+                "modality": modality,
+                "total_files": len(dicom_files)
+            },
+            "image_processing": {
+                "window_center": window_center,
+                "window_width": window_width,
+                "rescale_slope": rescale_slope,
+                "rescale_intercept": rescale_intercept,
+                "intensity_range": {
+                    "min": intensity_min,
+                    "max": intensity_max
+                }
+            }
+        }
+        
+        return jsonify({"status": "success", "data": metadata}), 200
+        
+    except Exception as e:
+        print("Error extracting DICOM metadata:", e)
+        return jsonify({"error": f"Failed to extract metadata: {str(e)}"}), 500
+
+
+
+@app.route("/api/download_dicom/<upload_id>", methods=["GET"])
+def download_dicom(upload_id):
+    safe_upload_id = secure_filename(upload_id)
+    if not safe_upload_id:
+        return jsonify({"error": "Invalid upload ID"}), 400
+
+    base_uploads = os.path.abspath(UPLOAD_FOLDER)
+    dicom_dir = os.path.abspath(os.path.join(base_uploads, safe_upload_id))
+
+    if not dicom_dir.startswith(base_uploads):
+        return jsonify({"error": "Path traversal attempt detected"}), 403
+
+    if not os.path.exists(dicom_dir):
+        return jsonify({"error": "Upload ID not found"}), 404
+
+    try:
+        zip_filename = f"{safe_upload_id}.zip"
+        zip_path = os.path.join(base_uploads, zip_filename)
+
+        import zipfile
+        with zipfile.ZipFile(zip_path, 'w') as zipf:
+            for root, _, files in os.walk(dicom_dir):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    arcname = os.path.relpath(file_path, dicom_dir)
+                    zipf.write(file_path, arcname)
+
+        return send_file(zip_path, mimetype="application/zip", as_attachment=True, download_name=zip_filename)
+    
+    except Exception as e:
+        print("Failed to create ZIP archive:", e)
+        return jsonify({"error": f"Failed to create ZIP archive: {e}"}), 500
+    
 @app.errorhandler(404)
 def not_found(error):
     return jsonify({"error": "Resource not found"}), 404

--- a/backend/test_metadata.py
+++ b/backend/test_metadata.py
@@ -1,0 +1,7 @@
+import requests
+
+response = requests.get("http://localhost:5000/api/render_dicom/fake-dicome-file/metadata")
+print(response.status_code)
+print(response.json())
+print(response.json().get("error", {}))
+


### PR DESCRIPTION
## Description
Added a new GET endpoint `/api/render_dicom/<upload_id>/metadata` that extracts physical dimensions and metadata from uploaded DICOM files before 3D processing. 

## Related Issue
Closes #issue #36

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security update (e.g., Dependabot fix, CodeQL patch)
- [ ] Chore (documentation, refactoring, etc.)

## How Has This Been Tested?
1.  test file added in later commit
2. 
3. 

## Tech Lead Checklist
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas (like VTK math or complex SQL).
- [ ] My changes generate no new warnings in the terminal or browser console.