### PR TITLE
endpoint to list active upload sessions #43

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -372,7 +372,8 @@ def list_sessions():
         return jsonify({"sessions": sessions}), 200
     
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        app.logger.exception("Failed to list sessions")
+        return jsonify({"error": "Failed to list sessions"}), 500
 
 
 @app.errorhandler(404)

--- a/backend/app.py
+++ b/backend/app.py
@@ -355,7 +355,26 @@ def download_dicom(upload_id):
     except Exception as e:
         print("Failed to create ZIP archive:", e)
         return jsonify({"error": f"Failed to create ZIP archive: {e}"}), 500
+
+# for list of active upload sessions
+@app.route("/api/sessions", methods=["GET"])
+def list_sessions():
+    try:
+        base_uploads = os.path.abspath(UPLOAD_FOLDER) 
+        if not os.path.exists(base_uploads): 
+            return jsonify({"sessions": []}), 200
+        
+        sessions = [
+            name for name in os.listdir(base_uploads)
+            if os.path.isdir(os.path.join(base_uploads, name))
+        ]
+        
+        return jsonify({"sessions": sessions}), 200
     
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
 @app.errorhandler(404)
 def not_found(error):
     return jsonify({"error": "Resource not found"}), 404


### PR DESCRIPTION
## Description
Adds a new endpoint to backend/app.py that reads the uploads/ directory and returns a JSON array of all active upload session folder names. Returns an empty array safely if no sessions exist

## Related Issue
Closes #43 

Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Security update (e.g., Dependabot fix, CodeQL patch)
- [ ] Chore (documentation, refactoring, etc.)

## How Has This Been Tested?
1. Started the Flask server locally with python app.py
2. Ran curl http://localhost:5000/api/sessions with an empty uploads folder which returned {"sessions": []} as expected
3. Confirmed only directories are listed 

## Tech Lead Checklist
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas (like VTK math or complex SQL).
- [ ] My changes generate no new warnings in the terminal or browser console.