### PR TITLE
Implement toast notifications for key user actions

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "gl-matrix": "^3.4.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hot-toast": "^2.6.0",
         "react-router-dom": "^7.18.2",
         "react-scripts": "^5.0.1",
         "react-spinners": "^0.17.0"
@@ -6258,6 +6259,12 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "license": "MIT"
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -8657,6 +8664,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
+      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -13847,6 +13863,23 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz",
       "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
       "license": "MIT"
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "gl-matrix": "^3.4.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.18.2",
     "react-scripts": "^5.0.1",
     "react-spinners": "^0.17.0"

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { Toaster } from "react-hot-toast";
 import "./App.css";
 
 import Login from "./pages/Login";
@@ -9,6 +10,7 @@ import Viewer from "./pages/Viewer";
 function App() {
   return (
     <BrowserRouter>
+      <Toaster position="top-right" toastOptions={{ duration: 4000 }} />
       <Routes>
         {/* Default: redirect root to /login */}
         <Route path="/" element={<Navigate to="/login" replace />} />

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import toast from "react-hot-toast";
 import "./LoginPage.css";
 
 function LoginPage({ apiBase, onLoginSuccess, onShowSignUp }) {
@@ -22,13 +23,17 @@ function LoginPage({ apiBase, onLoginSuccess, onShowSignUp }) {
       });
       const data = await res.json();
       if (!res.ok) {
-        setError(data.error || "Invalid username or password");
+        const message = data.error || "Invalid username or password";
+        setError(message);
+        toast.error(message);
         return;
       }
       localStorage.setItem("user_id", data.user_id); // ← store user_id
       onLoginSuccess(data.username);
     } catch (err) {
-      setError("Network error: " + err.message);
+      const message = "Network error: " + err.message;
+      setError(message);
+      toast.error(message);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/SignUpPage.js
+++ b/frontend/src/components/SignUpPage.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import toast from "react-hot-toast";
 import "./LoginPage.css";
 
 function SignUpPage({ apiBase, onSignupSuccess, onBackToLogin }) {
@@ -38,9 +39,12 @@ function SignUpPage({ apiBase, onSignupSuccess, onBackToLogin }) {
             if (onSignupSuccess) {
                 onSignupSuccess({ fullName, email, organization, ...data });
             }
+            toast.success("Account created successfully");
             if (onBackToLogin) onBackToLogin(); // ← removed alert(), go straight back to login
         } catch (err) {
-            setError(err.message);
+            const message = err.message || "Signup failed";
+            setError(message);
+            toast.error(message);
         } finally {
             setLoading(false);
         }

--- a/frontend/src/components/UploadSection.js
+++ b/frontend/src/components/UploadSection.js
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from "react";
+import toast from "react-hot-toast";
 import "./UploadSection.css";
 import VTKViewer from "./VTKViewer";
 
@@ -27,7 +28,7 @@ function UploadSection({ apiBase, onBack }) {
 
   const handleUpload = async () => {
     if (!files.length) {
-      alert("Please select one or more DICOM files first.");
+      toast.error("Please select one or more DICOM files first.");
       return;
     }
 
@@ -36,6 +37,8 @@ function UploadSection({ apiBase, onBack }) {
 
     const formData = new FormData();
     files.forEach((f) => formData.append("files", f));
+    const userId = localStorage.getItem("user_id");
+    if (userId) formData.append("user_id", userId);
 
     try {
       const res = await fetch(`${apiBase}/api/upload_dicom`, {
@@ -49,10 +52,11 @@ function UploadSection({ apiBase, onBack }) {
       }
 
       setUploadId(data.upload_id);
-      alert("Files uploaded successfully.");
+      toast.success("Files uploaded successfully");
     } catch (err) {
       console.error(err);
       setError(err.message);
+      toast.error(err.message || "Upload failed");
     } finally {
       setUploading(false);
     }
@@ -60,7 +64,7 @@ function UploadSection({ apiBase, onBack }) {
 
   const handleRender = () => {
     if (!uploadId) {
-      alert("Upload a DICOM series before rendering.");
+      toast.error("Upload a DICOM series before rendering.");
       return;
     }
 
@@ -73,6 +77,7 @@ function UploadSection({ apiBase, onBack }) {
     } catch (err) {
       console.error(err);
       setError("Failed to start rendering.");
+      toast.error("Failed to start rendering.");
     } finally {
       setRendering(false);
     }

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import toast from "react-hot-toast";
 import Sidebar from "../components/Sidebar";
 import WelcomeSection from "../components/WelcomeSection";
 import UploadSection from "../components/UploadSection";
 
-const API_BASE = "http://127.0.0.1:5000";
+const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
 
 /**
  * Dashboard page (route: /dashboard)
@@ -30,6 +31,7 @@ function Dashboard() {
 
     const handleLogout = () => {
         localStorage.removeItem("username");
+        toast.success("Logged out successfully");
         navigate("/login", { replace: true });
     };
 

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import LoginPage from "../components/LoginPage";
 import SignUpPage from "../components/SignUpPage";
 
-const API_BASE = "http://127.0.0.1:5000";
+const API_BASE = process.env.REACT_APP_API_BASE || "http://127.0.0.1:5000";
 
 /**
  * Login page (route: /login)
@@ -24,7 +24,10 @@ function Login() {
     if (showSignUp) {
         return (
             <div className="auth-wrapper">
-                <SignUpPage onBackToLogin={() => setShowSignUp(false)} />
+                <SignUpPage
+                    apiBase={API_BASE}
+                    onBackToLogin={() => setShowSignUp(false)}
+                />
             </div>
         );
     }


### PR DESCRIPTION
# Pull Request

**Addresses #70**

### What was changed?

- Added a global `react-hot-toast` container with a four-second default duration.
- Added error toasts for failed login and signup requests.
- Added success toasts for account creation, DICOM upload, and logout.
- Replaced upload/render alert dialogs with non-blocking error toasts.
- Passed the configured API base into signup and the stored user ID into uploads so those backend requests use the expected data.

### What changes are different from the original issue described solution?

`react-hot-toast` was selected as the lightweight notification library. Existing inline login, signup, and upload error text remains in place for persistent accessible feedback while the toast auto-dismisses. `REACT_APP_API_BASE` is supported for local integration testing, with the existing localhost value as the default.

### Why was it changed?

Key authentication, upload, and logout actions previously relied on inline text or blocking browser alerts. The global toast layer gives immediate feedback that survives route changes without disrupting the layout.

### How was it changed?

- `App.js` owns one top-right `Toaster`.
- Authentication and upload handlers call `toast.error` or `toast.success` alongside their existing state updates.
- Logout emits its success toast before navigating to login.
- Uploads include the `user_id` already stored by login.

### Screenshots that show the changes (if applicable)

Screenshots are not attached. The toast was visually verified at the default desktop viewport and at 390 x 844.

## Testing

- [x] `npm run build`
- [x] `CI=true npm test -- --watchAll=false --passWithNoTests` (the repository currently has no frontend tests)
- [x] Invalid login toast verified with a mocked API
- [x] Invalid signup toast verified with a mocked API
- [x] Logout success toast verified across the dashboard-to-login route change
- [x] Four-second auto-dismiss verified
- [x] Toast readability verified at 390 x 844
- [x] Upload success branch compiled and was checked against the mocked API contract; the browser driver could not attach a native DICOM file

The browser still reports the pre-existing Babel warning and missing `LoginPage.js` error caused by unchanged scripts in `public/index.html`; this PR does not add either message.

## Checklist

- [x] Existing style conventions followed
- [x] Changed lines reviewed
- [x] No hardcoded credentials or secrets added
- [x] No debug logs added

Closes #70